### PR TITLE
feature: add base tap bar with screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@react-native-firebase/app": "^17.3.1",
     "@react-native-firebase/auth": "^17.3.2",
+    "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "^6.0.8",
     "@react-navigation/native-stack": "^6.9.1",
     "@tanstack/react-query": "^4.2.1",
@@ -53,9 +54,9 @@
     "react-native": "0.68.0",
     "react-native-bootsplash": "^4.2.3",
     "react-native-config": "^1.4.6",
-    "react-native-localization": "^2.3.1",
     "react-native-date-picker": "^4.2.9",
     "react-native-keyboard-manager": "^6.5.11-0",
+    "react-native-localization": "^2.3.1",
     "react-native-mmkv": "^2.5.1",
     "react-native-safe-area-context": "^4.2.4",
     "react-native-screens": "^3.13.1"

--- a/src/features/account/screen/index.tsx
+++ b/src/features/account/screen/index.tsx
@@ -4,12 +4,12 @@ import { Text } from 'design-system';
 import { SafeAreaView } from 'dripsy';
 
 import styles from './styles';
-import type { HomePropTypes } from './types';
+import type { AccountPropTypes } from './types';
 
-const HomeScreen: FunctionComponent<HomePropTypes> = () => (
+const AccountScreen: FunctionComponent<AccountPropTypes> = () => (
   <SafeAreaView sx={styles.container}>
-    <Text accessibilityRole="text">Home Screen</Text>
+    <Text accessibilityRole="text">Account Screen</Text>
   </SafeAreaView>
 );
 
-export default HomeScreen;
+export default AccountScreen;

--- a/src/features/account/screen/styles.ts
+++ b/src/features/account/screen/styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/features/account/screen/types.ts
+++ b/src/features/account/screen/types.ts
@@ -1,0 +1,3 @@
+import { MainStackParamList, NativeStackScreenProps } from 'navigation/types';
+
+export type AccountPropTypes = NativeStackScreenProps<MainStackParamList, 'Account'>;

--- a/src/features/auth/sign-up/screen/index.tsx
+++ b/src/features/auth/sign-up/screen/index.tsx
@@ -97,6 +97,11 @@ const SignUpScreen: React.FunctionComponent<SignUpPropTypes> = ({
           autoCapitalize="none"
           autoCorrect={false}
           isRequired
+          // TODO: delete props
+          accessibilityLabelledBy={undefined}
+          accessibilityLanguage={undefined}
+          onPressIn={undefined}
+          onPressOut={undefined}
         />
         <DatePicker
           isDatePickerOpen={isDatePickerOpen}
@@ -123,6 +128,12 @@ const SignUpScreen: React.FunctionComponent<SignUpPropTypes> = ({
           isRequired
           autoCapitalize="none"
           autoCorrect={false}
+          // TODO: delete props
+          accessibilityLabelledBy={undefined}
+          accessibilityLanguage={undefined}
+          onPressIn={undefined}
+          onPressOut={undefined}
+          autoComplete={undefined}
         />
         <FormInput
           id="passwordConfirmation"
@@ -135,6 +146,12 @@ const SignUpScreen: React.FunctionComponent<SignUpPropTypes> = ({
           isRequired
           autoCapitalize="none"
           autoCorrect={false}
+          // TODO: delete props
+          accessibilityLabelledBy={undefined}
+          accessibilityLanguage={undefined}
+          onPressIn={undefined}
+          onPressOut={undefined}
+          autoComplete={undefined}
         />
       </ScrollView>
       <View sx={styles.content}>

--- a/src/features/chats/screen/index.tsx
+++ b/src/features/chats/screen/index.tsx
@@ -4,12 +4,12 @@ import { Text } from 'design-system';
 import { SafeAreaView } from 'dripsy';
 
 import styles from './styles';
-import type { HomePropTypes } from './types';
+import type { ChatsPropTypes } from './types';
 
-const HomeScreen: FunctionComponent<HomePropTypes> = () => (
+const ChatsScreen: FunctionComponent<ChatsPropTypes> = () => (
   <SafeAreaView sx={styles.container}>
-    <Text accessibilityRole="text">Home Screen</Text>
+    <Text accessibilityRole="text">Chats Screen</Text>
   </SafeAreaView>
 );
 
-export default HomeScreen;
+export default ChatsScreen;

--- a/src/features/chats/screen/styles.ts
+++ b/src/features/chats/screen/styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/features/chats/screen/types.ts
+++ b/src/features/chats/screen/types.ts
@@ -1,0 +1,3 @@
+import { MainStackParamList, NativeStackScreenProps } from 'navigation/types';
+
+export type ChatsPropTypes = NativeStackScreenProps<MainStackParamList, 'Chats'>;

--- a/src/features/connections/screen/index.tsx
+++ b/src/features/connections/screen/index.tsx
@@ -1,0 +1,15 @@
+import React, { FunctionComponent } from 'react';
+
+import { Text } from 'design-system';
+import { SafeAreaView } from 'dripsy';
+
+import styles from './styles';
+import type { ConnectionsPropTypes } from './types';
+
+const ConnectionsScreen: FunctionComponent<ConnectionsPropTypes> = () => (
+  <SafeAreaView sx={styles.container}>
+    <Text accessibilityRole="text">Connections Screen</Text>
+  </SafeAreaView>
+);
+
+export default ConnectionsScreen;

--- a/src/features/connections/screen/styles.ts
+++ b/src/features/connections/screen/styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/features/connections/screen/types.ts
+++ b/src/features/connections/screen/types.ts
@@ -1,0 +1,3 @@
+import { MainStackParamList, NativeStackScreenProps } from 'navigation/types';
+
+export type ConnectionsPropTypes = NativeStackScreenProps<MainStackParamList, 'Connections'>;

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -4,7 +4,7 @@ import RNBootSplash from 'react-native-bootsplash';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import AuthStack from 'navigation/stacks/auth';
-import MainStack from 'navigation/stacks/main';
+import MainTabNav from 'navigation/stacks/main';
 
 import { GlobalStore } from 'storage/stores';
 
@@ -25,10 +25,10 @@ const NavigationStack: React.FunctionComponent = () => {
           backgroundColor: '#FFFFFF',
         },
       }}>
-      {!user ? (
-        <AppStack.Screen name="Auth" component={AuthStack} />
+      {user ? (
+        <AppStack.Screen name="Main" component={MainTabNav} />
       ) : (
-        <AppStack.Screen name="Main" component={MainStack} />
+        <AppStack.Screen name="Auth" component={AuthStack} />
       )}
     </AppStack.Navigator>
   );

--- a/src/navigation/stacks/main/index.tsx
+++ b/src/navigation/stacks/main/index.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
+import AccountScreen from 'features/account/screen';
+import ChatsScreen from 'features/chats/screen';
+import ConnectionsScreen from 'features/connections/screen';
 import HomeScreen from 'features/home/screen';
 
 import { MainStackParamList } from 'navigation/types';
 
-const Stack = createNativeStackNavigator<MainStackParamList>();
+const Tab = createBottomTabNavigator<MainStackParamList>();
 
-const MainStack = () => (
-  <Stack.Navigator initialRouteName="Home">
-    <Stack.Screen name="Home" component={HomeScreen} />
-  </Stack.Navigator>
+const MainTabNav = () => (
+  <Tab.Navigator>
+    <Tab.Screen name="Home" component={HomeScreen} />
+    <Tab.Screen name="Chats" component={ChatsScreen} />
+    <Tab.Screen name="Connections" component={ConnectionsScreen} />
+    <Tab.Screen name="Account" component={AccountScreen} />
+  </Tab.Navigator>
 );
 
-export default MainStack;
+export default MainTabNav;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,6 +9,9 @@ const AuthStackScreens = {
 
 const MainStackScreens = {
   Home: 'Home',
+  Chats: 'Chats',
+  Connections: 'Connections',
+  Account: 'Account',
 } as const;
 
 export enum Stacks {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,6 +1474,15 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
+"@react-navigation/bottom-tabs@^6.5.7":
+  version "6.5.7"
+  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-6.5.7.tgz#08470c96e0d11481422214bb98f0ff034038856c"
+  integrity sha512-9oZYyRu2z7+1pr2dX5V54rHFPmlj4ztwQxFe85zwpnGcPtGIsXj7VCIdlHnjRHJBBFCszvJGQpYY6/G2+DfD+A==
+  dependencies:
+    "@react-navigation/elements" "^1.3.17"
+    color "^4.2.3"
+    warn-once "^0.1.0"
+
 "@react-navigation/core@^6.4.8":
   version "6.4.8"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.4.8.tgz#a18e106d3c59cdcfc4ce53f7344e219ed35c88ed"


### PR DESCRIPTION
### Pull request type

<!-- Please check the type of change your PR introduces: -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

---

### Description

- Add base tap bar with the four options and each screen 
- FYI: I didn't include i18n translation in each screen because there are going to change
- **TO DO**: In next PR I will add styles to the tap bar and will be like in figma I just didn't want to have all included it in 1 PR

---

#### Jira board reference

- [Setup tap bar](https://rootstrap.atlassian.net/browse/TH-55?atlOrigin=eyJpIjoiNjkxYWI5ZTkzNmVlNDIxNWIzM2JkMDk5MjJmYjhjYTIiLCJwIjoiaiJ9)

#### Tasks:

- [X] Tested on IOS
- [X] Tested on Android
- [ ] Tested on a small device
- [ ] Tested on a real device
- [ ] Tested all flows related with this PR changes
- [ ] Tested accessibility
- [ ] Added tests

---

#### Preview

**IOS:**

https://user-images.githubusercontent.com/40902023/224788509-e58730e0-4625-4111-90bb-85795a593d85.mp4


**ANDROID:**

[android.webm](https://user-images.githubusercontent.com/40902023/224788587-628ea037-aa11-4d48-9406-40bba151b5e2.webm)



